### PR TITLE
Add flexibility

### DIFF
--- a/contracts/Everdragons2Genesis.sol
+++ b/contracts/Everdragons2Genesis.sol
@@ -16,6 +16,7 @@ import "@ndujalabs/wormhole721/contracts/Wormhole721Upgradeable.sol";
 
 import "./interfaces/IEverdragons2Genesis.sol";
 import "./interfaces/IManager.sol";
+
 //import "hardhat/console.sol";
 
 contract Everdragons2Genesis is

--- a/contracts/Everdragons2GenesisBridged.sol
+++ b/contracts/Everdragons2GenesisBridged.sol
@@ -15,6 +15,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@ndujalabs/wormhole721/contracts/Wormhole721Upgradeable.sol";
 
 import "./interfaces/IEverdragons2GenesisBridged.sol";
+
 //import "hardhat/console.sol";
 
 contract Everdragons2GenesisBridged is

--- a/contracts/GenesisFarm.sol
+++ b/contracts/GenesisFarm.sol
@@ -18,7 +18,7 @@ contract GenesisFarm is Ownable, IManager {
   IEverdragons2Genesis public everdragons2Genesis;
 
   bytes32 public root;
-  uint256 private _nextTokenId = 1;
+  uint256 private _nextTokenId;
   uint256 public maxForSale;
   uint256 public proceedsBalance;
   uint256 public price;
@@ -40,7 +40,8 @@ contract GenesisFarm is Ownable, IManager {
     require(everdragons2Genesis.mintEnded() == false, "Not an E2 token");
     require(saleStartAt_ > block.timestamp, "Invalid sale start time");
     maxForSale = maxForSale_; // 250
-    maxClaimable = maxClaimable_; // 600
+    maxClaimable = maxClaimable_; // 350
+    _nextTokenId = maxClaimable_ + 1;
     price = uint256(price_).mul(10**18);
     saleStartAt = saleStartAt_;
   }
@@ -52,9 +53,8 @@ contract GenesisFarm is Ownable, IManager {
   function claimRemainingTokens(address treasury, uint256 limit) external onlyOwner {
     require(claimingEnded, "Claiming not ended yet");
     uint256 j = 0;
-    uint256 min = 1 + (_lastUnclaimed > 0 ? _lastUnclaimed : maxForSale);
     uint256 k = 0;
-    for (uint256 i = min; i <= maxClaimable; i++) {
+    for (uint256 i = _lastUnclaimed + 1; i <= maxClaimable; i++) {
       if (!_claimed[i]) {
         j++;
         k = i;
@@ -94,7 +94,7 @@ contract GenesisFarm is Ownable, IManager {
 
   function buyTokens(uint256 quantity) external payable {
     require(block.timestamp >= saleStartAt, "Sale not started yet");
-    require(_nextTokenId + quantity - 1 <= maxForSale, "Not enough tokens left");
+    require(_nextTokenId + quantity - 1 <= maxForSale + maxClaimable, "Not enough tokens left");
     require(msg.value >= price.mul(quantity), "Insufficient payment");
     uint256 nextId = _nextTokenId;
     for (uint256 i = 0; i < quantity; i++) {

--- a/contracts/mocks/FarmMock.sol
+++ b/contracts/mocks/FarmMock.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.3;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "../interfaces/IEverdragons2Genesis.sol";
+
+contract FarmMock is Ownable {
+  IEverdragons2Genesis public e2;
+
+  constructor(address e2_) {
+    e2 = IEverdragons2Genesis(e2_);
+  }
+
+  function mint(address recipient, uint256 tokenId) external onlyOwner {
+    e2.mint(recipient, tokenId);
+  }
+}

--- a/export/ABIs.json
+++ b/export/ABIs.json
@@ -1,5 +1,5 @@
 {
-  "when": "2022-02-06T01:46:18.192Z",
+  "when": "2022-02-06T01:56:43.893Z",
   "contracts": {
     "Everdragons2Genesis": [
       {

--- a/parked-contracts/mocks/DragonsFarmMock.sol
+++ b/parked-contracts/mocks/DragonsFarmMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.3;
+pragma solidity ^0.8.3;
 
 import "../IEverdragons2.sol";
 


### PR DESCRIPTION
This revert the ID order. Before, the ID for sale where starting from 1 and reach the maxForSale. This was not allowing flexibility. Now, the ID from 1 to 350 are reserved to the whitelisted, since they are fixed for sure, and the first ID for sale is 351. This way, if we decide to sell more eggs, we can just update the maxForSale and make a second batch.