### PR TITLE
Fix approve pool

### DIFF
--- a/contracts/Everdragons2GenesisBridgedV2.sol
+++ b/contracts/Everdragons2GenesisBridgedV2.sol
@@ -113,8 +113,8 @@ contract Everdragons2GenesisBridgedV2 is
   }
 
   function stake(uint256 tokenID) external onlyPool {
-    // will revert if token does not exist
-    ownerOf(tokenID);
+    // pool must be approved to mark the token as staked
+    require(getApproved(tokenID) == _msgSender() || isApprovedForAll(ownerOf(tokenID), _msgSender()), "Pool not approved");
     staked[tokenID] = _msgSender();
   }
 

--- a/contracts/Everdragons2GenesisV2.sol
+++ b/contracts/Everdragons2GenesisV2.sol
@@ -137,8 +137,8 @@ contract Everdragons2GenesisV2 is
   }
 
   function stake(uint256 tokenID) external onlyPool {
-    // will revert if token does not exist
-    ownerOf(tokenID);
+    // pool must be approved to mark the token as staked
+    require(getApproved(tokenID) == _msgSender() || isApprovedForAll(ownerOf(tokenID), _msgSender()), "Pool not approved");
     staked[tokenID] = _msgSender();
   }
 

--- a/test/Everdragons2GenesisV2.test.js
+++ b/test/Everdragons2GenesisV2.test.js
@@ -95,6 +95,10 @@ describe("Everdragons2GenesisV2", async function () {
       // await everdragons2Genesis.endMinting()
 
       await everdragons2Genesis.setPool(pool.address)
+
+      await assertThrowsMessage(pool.connect(buyer1).stakeEvd2(13), "Pool not approved")
+
+      await everdragons2Genesis.connect(buyer1).approve(pool.address, 13)
       await pool.connect(buyer1).stakeEvd2(13)
       expect(await upgraded.isStaked(13)).equal(true)
       expect(await upgraded.getStaker(13)).equal(pool.address)


### PR DESCRIPTION
This adds a missing piece: the pool must be approved to mark the token as staked.