### PR TITLE
Renaming staking function to locking

### DIFF
--- a/contracts/V2/Everdragons2GenesisBridgedV3.sol
+++ b/contracts/V2/Everdragons2GenesisBridgedV3.sol
@@ -15,11 +15,11 @@ import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 
 import "./interfaces/IStakingPool.sol";
 
-import "./interfaces/IEverdragons2GenesisV3.sol";
+import "./interfaces/ILockable.sol";
 
 //import "hardhat/console.sol";
 
-contract Everdragons2GenesisBridgedV3 is IEverdragons2GenesisV3,
+contract Everdragons2GenesisBridgedV3 is ILockable,
   Initializable,
   ERC721Upgradeable,
   ERC721PlayableUpgradeable,

--- a/contracts/V2/Everdragons2GenesisBridgedV3.sol
+++ b/contracts/V2/Everdragons2GenesisBridgedV3.sol
@@ -145,7 +145,7 @@ contract Everdragons2GenesisBridgedV3 is IEverdragons2GenesisV3,
     require(isLocked(tokenId), "not a locked tokenId");
     require(!pools[staked[tokenId]], "locker is still active");
     delete staked[tokenId];
-    emit LockRemoved(tokenId);
+    emit ForcefullyUnlocked(tokenId);
   }
 
   // manage approval

--- a/contracts/V2/Everdragons2GenesisBridgedV3.sol
+++ b/contracts/V2/Everdragons2GenesisBridgedV3.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.11;
+
+// Authors: Francesco Sullo <francesco@sullo.co>
+//          Emanuele Cesena <emanuele@ndujalabs.com>
+// Everdragons2, https://everdragons2.com
+
+import "@ndujalabs/erc721playable/contracts/ERC721PlayableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@ndujalabs/wormhole721-0-3-0/contracts/Wormhole721Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
+
+import "./interfaces/IStakingPool.sol";
+
+import "./interfaces/IEverdragons2GenesisV3.sol";
+
+//import "hardhat/console.sol";
+
+contract Everdragons2GenesisBridgedV3 is IEverdragons2GenesisV3,
+  Initializable,
+  ERC721Upgradeable,
+  ERC721PlayableUpgradeable,
+  ERC721EnumerableUpgradeable,
+  Wormhole721Upgradeable
+{
+  using AddressUpgradeable for address;
+
+  bool private _baseTokenURIFrozen;
+  string private _baseTokenURI;
+
+  mapping(address => bool) public pools;
+  mapping(uint256 => address) public staked;
+
+  modifier onlyPool() {
+    require(pools[_msgSender()], "Forbidden");
+    _;
+  }
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() initializer {}
+
+  function initialize() public initializer {
+    __Wormhole721_init("Everdragons2 Genesis Token", "E2GT");
+    __ERC721Enumerable_init();
+    // tokenURI pre-reveal
+    _baseTokenURI = "https://img.everdragons2.com/e2gt/";
+  }
+
+  function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+
+  function _beforeTokenTransfer(
+    address from,
+    address to,
+    uint256 tokenId
+  ) internal override(ERC721Upgradeable, ERC721PlayableUpgradeable, ERC721EnumerableUpgradeable) {
+    require(!isLocked(tokenId), "Dragon is staked");
+    super._beforeTokenTransfer(from, to, tokenId);
+  }
+
+  function supportsInterface(bytes4 interfaceId)
+    public
+    view
+    override(Wormhole721Upgradeable, ERC721Upgradeable, ERC721PlayableUpgradeable, ERC721EnumerableUpgradeable)
+    returns (bool)
+  {
+    return super.supportsInterface(interfaceId);
+  }
+
+  function _baseURI() internal view virtual override returns (string memory) {
+    return _baseTokenURI;
+  }
+
+  function updateTokenURI(string memory uri) external onlyOwner {
+    require(!_baseTokenURIFrozen, "baseTokenUri has been frozen");
+    // after revealing, this allows to set up a final uri
+    _baseTokenURI = uri;
+  }
+
+  function freezeTokenURI() external onlyOwner {
+    _baseTokenURIFrozen = true;
+  }
+
+  function contractURI() public view returns (string memory) {
+    return _baseURI();
+  }
+
+
+  // locks
+
+  function isLocked(uint256 tokenId) public view override returns (bool) {
+    return staked[tokenId] != address(0);
+  }
+
+  function lockerOf(uint256 tokenId) external view override returns (address) {
+    return staked[tokenId];
+  }
+
+  function isLocker(address locker) public view override returns (bool) {
+    return pools[locker];
+  }
+
+  function setLocker(address locker) external override onlyOwner {
+    require(locker.isContract(), "locker not a contract");
+    pools[locker] = true;
+    emit LockerSet(locker);
+  }
+
+  function removeLocker(address locker) external override onlyOwner {
+    require(pools[locker], "not an active locker");
+    delete pools[locker];
+    emit LockerRemoved(locker);
+  }
+
+  function hasLocks(address owner) public view override returns (bool) {
+    uint256 balance = balanceOf(owner);
+    for (uint256 i = 0; i < balance; i++) {
+      uint256 id = tokenOfOwnerByIndex(owner, i);
+      if (isLocked(id)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function lock(uint256 tokenId) external override onlyPool {
+    // locker must be approved to mark the token as locked
+    require(isLocker(_msgSender()), "Not an authorized locker");
+    require(getApproved(tokenId) == _msgSender() || isApprovedForAll(ownerOf(tokenId), _msgSender()), "Locker not approved");
+    staked[tokenId] = _msgSender();
+    emit Locked(tokenId);
+  }
+
+  function unlock(uint256 tokenId) external override onlyPool {
+    // will revert if token does not exist
+    require(staked[tokenId] == _msgSender(), "wrong locker");
+    delete staked[tokenId];
+    emit Unlocked(tokenId);
+  }
+
+  // emergency function in case a compromised locker is removed
+  function unlockIfRemovedLocker(uint256 tokenId) external override onlyOwner {
+    require(isLocked(tokenId), "not a locked tokenId");
+    require(!pools[staked[tokenId]], "locker is still active");
+    delete staked[tokenId];
+    emit LockRemoved(tokenId);
+  }
+
+  // manage approval
+
+  function approve(address to, uint256 tokenId) public override {
+    require(!isLocked(tokenId), "locked asset");
+    super.approve(to, tokenId);
+  }
+
+  function getApproved(uint256 tokenId) public view override returns (address) {
+    if (isLocked(tokenId)) {
+      return address(0);
+    }
+    return super.getApproved(tokenId);
+  }
+
+  function setApprovalForAll(address operator, bool approved) public override {
+    require(!approved || !hasLocks(_msgSender()), "at least one asset is locked");
+    super.setApprovalForAll(operator, approved);
+  }
+
+  function isApprovedForAll(address owner, address operator) public view override returns (bool) {
+    if (hasLocks(owner)) {
+      return false;
+    }
+    return super.isApprovedForAll(owner, operator);
+  }
+}

--- a/contracts/V2/Everdragons2GenesisV3.sol
+++ b/contracts/V2/Everdragons2GenesisV3.sol
@@ -167,7 +167,7 @@ contract Everdragons2GenesisV3 is IEverdragons2GenesisV3,
     require(isLocked(tokenId), "not a locked tokenId");
     require(!pools[staked[tokenId]], "locker is still active");
     delete staked[tokenId];
-    emit LockRemoved(tokenId);
+    emit ForcefullyUnlocked(tokenId);
   }
 
   // manage approval

--- a/contracts/V2/Everdragons2GenesisV3.sol
+++ b/contracts/V2/Everdragons2GenesisV3.sol
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.11;
+
+// Authors: Francesco Sullo <francesco@sullo.co>
+//          Emanuele Cesena <emanuele@ndujalabs.com>
+// Everdragons2, https://everdragons2.com
+
+import "@ndujalabs/erc721playable/contracts/ERC721PlayableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@ndujalabs/wormhole721-0-3-0/contracts/Wormhole721Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
+
+import "./interfaces/IStakingPool.sol";
+import "./interfaces/IEverdragons2GenesisV3.sol";
+
+//import "hardhat/console.sol";
+
+contract Everdragons2GenesisV3 is IEverdragons2GenesisV3,
+  Initializable,
+  ERC721Upgradeable,
+  ERC721PlayableUpgradeable,
+  ERC721EnumerableUpgradeable,
+  Wormhole721Upgradeable
+{
+  using AddressUpgradeable for address;
+
+  bool private _mintEnded;
+  bool private _baseTokenURIFrozen;
+  string private _baseTokenURI;
+
+  address public manager;
+
+  mapping(address => bool) public pools;
+  mapping(uint256 => address) public staked;
+
+  modifier onlyPool() {
+    require(pools[_msgSender()], "Forbidden");
+    _;
+  }
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() initializer {}
+
+  function initialize() public initializer {
+    __Wormhole721_init("Everdragons2 Genesis Token", "E2GT");
+    __ERC721Enumerable_init();
+    // tokenURI pre-reveal
+    _baseTokenURI = "https://img.everdragons2.com/e2gt/";
+  }
+
+  function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+
+  function _beforeTokenTransfer(
+    address from,
+    address to,
+    uint256 tokenId
+  ) internal override(ERC721Upgradeable, ERC721PlayableUpgradeable, ERC721EnumerableUpgradeable) {
+    require(!isLocked(tokenId), "Dragon is staked");
+    super._beforeTokenTransfer(from, to, tokenId);
+  }
+
+  function supportsInterface(bytes4 interfaceId)
+    public
+    view
+    override(Wormhole721Upgradeable, ERC721Upgradeable, ERC721PlayableUpgradeable, ERC721EnumerableUpgradeable)
+    returns (bool)
+  {
+    return super.supportsInterface(interfaceId);
+  }
+
+  function airdrop(address[] memory recipients, uint256[] memory tokenIDs) external onlyOwner {
+    require(totalSupply() < 600, "Airdrop completed");
+    require(recipients.length == tokenIDs.length, "Inconsistent lengths");
+    for (uint256 i = 0; i < recipients.length; i++) {
+      require(tokenIDs[i] < 601, "ID out of range");
+      if (totalSupply() < 601) {
+        _safeMint(recipients[i], tokenIDs[i]);
+      } else {
+        _mintEnded = true;
+        return;
+      }
+    }
+    if (totalSupply() == 600) {
+      _mintEnded = true;
+    }
+  }
+
+  function mintEnded() public view virtual returns (bool) {
+    return _mintEnded;
+  }
+
+  function _baseURI() internal view virtual override returns (string memory) {
+    return _baseTokenURI;
+  }
+
+  function updateTokenURI(string memory uri) external onlyOwner {
+    require(!_baseTokenURIFrozen, "baseTokenUri has been frozen");
+    // after revealing, this allows to set up a final uri
+    _baseTokenURI = uri;
+  }
+
+  function freezeTokenURI() external onlyOwner {
+    _baseTokenURIFrozen = true;
+  }
+
+  function contractURI() public view returns (string memory) {
+    return string(abi.encodePacked(_baseTokenURI, "0"));
+  }
+
+  // locks
+
+  function isLocked(uint256 tokenId) public view override returns (bool) {
+    return staked[tokenId] != address(0);
+  }
+
+  function lockerOf(uint256 tokenId) external view override returns (address) {
+    return staked[tokenId];
+  }
+
+  function isLocker(address locker) public view override returns (bool) {
+    return pools[locker];
+  }
+
+  function setLocker(address locker) external override onlyOwner {
+    require(locker.isContract(), "locker not a contract");
+    pools[locker] = true;
+    emit LockerSet(locker);
+  }
+
+  function removeLocker(address locker) external override onlyOwner {
+    require(pools[locker], "not an active locker");
+    delete pools[locker];
+    emit LockerRemoved(locker);
+  }
+
+  function hasLocks(address owner) public view override returns (bool) {
+    uint256 balance = balanceOf(owner);
+    for (uint256 i = 0; i < balance; i++) {
+      uint256 id = tokenOfOwnerByIndex(owner, i);
+      if (isLocked(id)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function lock(uint256 tokenId) external override onlyPool {
+    // locker must be approved to mark the token as locked
+    require(isLocker(_msgSender()), "Not an authorized locker");
+    require(getApproved(tokenId) == _msgSender() || isApprovedForAll(ownerOf(tokenId), _msgSender()), "Locker not approved");
+    staked[tokenId] = _msgSender();
+    emit Locked(tokenId);
+  }
+
+  function unlock(uint256 tokenId) external override onlyPool {
+    // will revert if token does not exist
+    require(staked[tokenId] == _msgSender(), "wrong locker");
+    delete staked[tokenId];
+    emit Unlocked(tokenId);
+  }
+
+  // emergency function in case a compromised locker is removed
+  function unlockIfRemovedLocker(uint256 tokenId) external override onlyOwner {
+    require(isLocked(tokenId), "not a locked tokenId");
+    require(!pools[staked[tokenId]], "locker is still active");
+    delete staked[tokenId];
+    emit LockRemoved(tokenId);
+  }
+
+  // manage approval
+
+  function approve(address to, uint256 tokenId) public override {
+    require(!isLocked(tokenId), "locked asset");
+    super.approve(to, tokenId);
+  }
+
+  function getApproved(uint256 tokenId) public view override returns (address) {
+    if (isLocked(tokenId)) {
+      return address(0);
+    }
+    return super.getApproved(tokenId);
+  }
+
+  function setApprovalForAll(address operator, bool approved) public override {
+    require(!approved || !hasLocks(_msgSender()), "at least one asset is locked");
+    super.setApprovalForAll(operator, approved);
+  }
+
+  function isApprovedForAll(address owner, address operator) public view override returns (bool) {
+    if (hasLocks(owner)) {
+      return false;
+    }
+    return super.isApprovedForAll(owner, operator);
+  }
+}

--- a/contracts/V2/Everdragons2GenesisV3.sol
+++ b/contracts/V2/Everdragons2GenesisV3.sol
@@ -14,11 +14,11 @@ import "@ndujalabs/wormhole721-0-3-0/contracts/Wormhole721Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 
 import "./interfaces/IStakingPool.sol";
-import "./interfaces/IEverdragons2GenesisV3.sol";
+import "./interfaces/ILockable.sol";
 
 //import "hardhat/console.sol";
 
-contract Everdragons2GenesisV3 is IEverdragons2GenesisV3,
+contract Everdragons2GenesisV3 is ILockable,
   Initializable,
   ERC721Upgradeable,
   ERC721PlayableUpgradeable,

--- a/contracts/V2/interfaces/IEverdragons2GenesisV3.sol
+++ b/contracts/V2/interfaces/IEverdragons2GenesisV3.sol
@@ -4,15 +4,9 @@ pragma solidity 0.8.11;
 interface IEverdragons2GenesisV3 {
   event LockerSet(address locker);
   event LockerRemoved(address locker);
-  event LockRemoved(uint256 tokenId);
+  event ForcefullyUnlocked(uint256 tokenId);
   event Locked(uint256 tokendId);
   event Unlocked(uint256 tokendId);
-
-  function updateTokenURI(string memory uri) external;
-
-  function freezeTokenURI() external;
-
-  function contractURI() external view returns (string memory);
 
   function isLocked(uint256 tokenID) external view returns (bool);
 

--- a/contracts/V2/interfaces/IEverdragons2GenesisV3.sol
+++ b/contracts/V2/interfaces/IEverdragons2GenesisV3.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.11;
+
+interface IEverdragons2GenesisV3 {
+  event LockerSet(address locker);
+  event LockerRemoved(address locker);
+  event LockRemoved(uint256 tokenId);
+  event Locked(uint256 tokendId);
+  event Unlocked(uint256 tokendId);
+
+  function updateTokenURI(string memory uri) external;
+
+  function freezeTokenURI() external;
+
+  function contractURI() external view returns (string memory);
+
+  function isLocked(uint256 tokenID) external view returns (bool);
+
+  function lockerOf(uint256 tokenID) external view returns (address);
+
+  function isLocker(address _locker) external view returns (bool);
+
+  function setLocker(address pool) external;
+
+  function removeLocker(address pool) external;
+
+  function hasLocks(address owner) external view returns (bool);
+
+  function lock(uint256 tokenID) external;
+
+  function unlock(uint256 tokenID) external;
+
+  function unlockIfRemovedLocker(uint256 tokenID) external;
+}

--- a/contracts/V2/interfaces/ILockable.sol
+++ b/contracts/V2/interfaces/ILockable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.11;
 
-interface IEverdragons2GenesisV3 {
+interface ILockable {
   event LockerSet(address locker);
   event LockerRemoved(address locker);
   event ForcefullyUnlocked(uint256 tokenId);

--- a/contracts/V2/mocks/StakingPoolMock.sol
+++ b/contracts/V2/mocks/StakingPoolMock.sol
@@ -11,7 +11,7 @@ contract StakingPoolMock is IStakingPool {
     e2 = Everdragons2GenesisV2(e2_);
   }
 
-  function id() external view returns (bytes32) {
+  function id() external pure returns (bytes32) {
     return keccak256("Everdragons2Pool");
   }
 

--- a/contracts/V2/mocks/StakingPoolMockV3.sol
+++ b/contracts/V2/mocks/StakingPoolMockV3.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.11;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "../Everdragons2GenesisV3.sol";
+
+contract StakingPoolMockV3 is IStakingPool {
+  Everdragons2GenesisV3 public e2;
+
+  constructor(address e2_) {
+    e2 = Everdragons2GenesisV3(e2_);
+  }
+
+  function id() external view returns (bytes32) {
+    return keccak256("Everdragons2Pool");
+  }
+
+  function stakeEvd2(uint256 tokenId) external {
+    e2.lock(tokenId);
+  }
+
+  function unstakeEvd2(uint256 tokenId) external {
+    e2.unlock(tokenId);
+  }
+}

--- a/contracts/V2/mocks/StakingPoolMockV3.sol
+++ b/contracts/V2/mocks/StakingPoolMockV3.sol
@@ -11,7 +11,7 @@ contract StakingPoolMockV3 is IStakingPool {
     e2 = Everdragons2GenesisV3(e2_);
   }
 
-  function id() external view returns (bytes32) {
+  function id() external pure returns (bytes32) {
     return keccak256("Everdragons2Pool");
   }
 

--- a/test/Everdragons2GenesisV3.test.js
+++ b/test/Everdragons2GenesisV3.test.js
@@ -1,0 +1,133 @@
+const {expect, assert} = require("chai")
+const _ = require('lodash')
+const keccak256 = require('keccak256')
+const {MerkleTree} = require('merkletreejs')
+const fs = require('fs-extra')
+const path = require('path')
+
+const {
+  initEthers,
+  assertThrowsMessage,
+  signPackedData,
+  normalize,
+  getTimestamp,
+  increaseBlockTimestampBy
+} = require('./helpers')
+const whitelist = require('./fixtures/whitelist.json');
+
+describe("Everdragons2GenesisV23", async function () {
+
+  let Everdragons2Genesis
+  let Everdragons2GenesisV2
+  let Everdragons2GenesisV3
+  let everdragons2Genesis
+  let StakingPool
+  let pool
+  let GenesisFarm
+  let genesisFarm
+  let owner, wallet, buyer1, buyer2, buyer3, treasury, member, beneficiary1, beneficiary2,
+      whitelisted1, whitelisted2, whitelisted3, openSea
+
+  before(async function () {
+    [owner, wallet, buyer1, buyer2, buyer3, treasury, member, beneficiary1, beneficiary2,
+      whitelisted1, whitelisted2, whitelisted3, openSea] = await ethers.getSigners()
+    Everdragons2Genesis = await ethers.getContractFactory("Everdragons2Genesis")
+    Everdragons2GenesisV2 = await ethers.getContractFactory("Everdragons2GenesisV2")
+    Everdragons2GenesisV3 = await ethers.getContractFactory("Everdragons2GenesisV3")
+    GenesisFarm = await ethers.getContractFactory("GenesisFarm")
+    StakingPool = await ethers.getContractFactory("StakingPoolMockV3")
+    initEthers(ethers)
+  })
+
+  async function initAndDeploy(saleStartAt) {
+    if (!saleStartAt) {
+      saleStartAt = (await getTimestamp()) + 10
+    }
+    everdragons2Genesis = await upgrades.deployProxy(Everdragons2Genesis, []);
+    await everdragons2Genesis.deployed()
+    expect(await everdragons2Genesis.contractURI(), 'https://img.everdragons2.com/e2gt/0')
+    genesisFarm = await GenesisFarm.deploy(
+        everdragons2Genesis.address,
+        25, // maxForSale
+        10, // maxClaimable
+        normalize(10), // price in MATIC
+        saleStartAt)
+    await genesisFarm.deployed()
+    await everdragons2Genesis.setManager(genesisFarm.address)
+  }
+
+    beforeEach(async function () {
+      await initAndDeploy()
+      await increaseBlockTimestampBy(11)
+    })
+
+    it("upgrade without issues", async function () {
+
+      expect(await genesisFarm.connect(buyer1).buyTokens(3, {
+        value: ethers.BigNumber.from(await genesisFarm.price()).mul(3)
+      }))
+          .to.emit(everdragons2Genesis, 'Transfer')
+          .withArgs(ethers.constants.AddressZero, buyer1.address, 11)
+          .to.emit(everdragons2Genesis, 'Transfer')
+          .withArgs(ethers.constants.AddressZero, buyer1.address, 12)
+          .to.emit(everdragons2Genesis, 'Transfer')
+          .withArgs(ethers.constants.AddressZero, buyer1.address, 13)
+
+      expect(await genesisFarm.nextTokenId()).equal(14)
+
+      let upgraded = await upgrades.upgradeProxy(everdragons2Genesis.address, Everdragons2GenesisV2);
+      await upgraded.deployed();
+
+      expect(everdragons2Genesis.address).equal(upgraded.address)
+
+      upgraded = await upgrades.upgradeProxy(everdragons2Genesis.address, Everdragons2GenesisV3);
+      await upgraded.deployed();
+
+      expect(everdragons2Genesis.address).equal(upgraded.address)
+
+      everdragons2Genesis = Everdragons2GenesisV3.attach(upgraded.address)
+
+      expect(await everdragons2Genesis.airdrop([buyer2.address, buyer3.address, buyer3.address], [14, 15, 16]))
+          .to.emit(everdragons2Genesis, 'Transfer')
+          .withArgs(ethers.constants.AddressZero, buyer2.address, 14)
+          .to.emit(everdragons2Genesis, 'Transfer')
+          .withArgs(ethers.constants.AddressZero, buyer3.address, 15)
+          .to.emit(everdragons2Genesis, 'Transfer')
+          .withArgs(ethers.constants.AddressZero, buyer3.address, 16)
+
+      expect(await everdragons2Genesis.connect(buyer3).transferFrom(buyer3.address, buyer2.address, 16))
+          .to.emit(everdragons2Genesis, 'Transfer')
+          .withArgs(buyer3.address, buyer2.address, 16)
+
+      pool = await StakingPool.deploy(everdragons2Genesis.address)
+      await pool.deployed()
+
+      // await everdragons2Genesis.endMinting()
+
+      await assertThrowsMessage(pool.connect(buyer1).stakeEvd2(13), "Forbidden")
+
+      await everdragons2Genesis.setLocker(pool.address)
+      await assertThrowsMessage(pool.connect(buyer1).stakeEvd2(13), "Locker not approved")
+
+      await everdragons2Genesis.connect(buyer1).setApprovalForAll(pool.address, true)
+
+      expect(await pool.connect(buyer1).stakeEvd2(13))
+          .to.emit(everdragons2Genesis, 'Locked')
+
+      await everdragons2Genesis.connect(buyer2).approve(pool.address, 14)
+      await pool.connect(buyer2).stakeEvd2(14)
+      expect(await upgraded.isLocked(14)).equal(true)
+      expect(await upgraded.lockerOf(14)).equal(pool.address)
+
+      expect(everdragons2Genesis.connect(buyer2).approve(openSea.address, 14)).revertedWith("locked asset")
+
+      expect(everdragons2Genesis.connect(buyer2).setApprovalForAll(openSea.address, true)).revertedWith("at least one asset is locked")
+
+      await pool.connect(buyer2).unstakeEvd2(14)
+      await everdragons2Genesis.connect(buyer2).approve(openSea.address, 14)
+      expect(await everdragons2Genesis.getApproved(14)).equal(openSea.address)
+
+    })
+
+
+})


### PR DESCRIPTION
This renames the staking functions, the related events, etc. from using the word _stake_ to use the word _lock_, more generic and versatile. It also tests that the contracts are still upgradeable without problems.